### PR TITLE
Fixing laziness test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,9 +35,9 @@ lazy val guava = project
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"          %% "zio"          % "1.0.0-RC13",
+      "dev.zio"          %% "zio"          % "1.0.0-RC14",
       "com.google.guava" % "guava"         % "28.1-jre",
-      "dev.zio"          %% "zio-test"     % "1.0.0-RC13" % Test,
-      "dev.zio"          %% "zio-test-sbt" % "1.0.0-RC13" % Test
+      "dev.zio"          %% "zio-test"     % "1.0.0-RC14" % Test,
+      "dev.zio"          %% "zio-test-sbt" % "1.0.0-RC14" % Test
     )
   )

--- a/src/test/scala/zio/interop/GuavaSpec.scala
+++ b/src/test/scala/zio/interop/GuavaSpec.scala
@@ -18,7 +18,7 @@ object GuavaSpec {
             evaluated = true
             Futures.immediateFuture(())
           }, Executors.newCachedThreadPool())
-        assertM(Task.fromListenableFuture(UIO.effectTotal(ftr)).as(evaluated).run, succeeds(isFalse))
+        assertM(Task.fromListenableFuture(UIO.effectTotal(ftr)).when(false).as(evaluated), isFalse)
       },
       testM("catch exceptions thrown by lazy block") {
         val ex                                    = new Exception("no future for you!")


### PR DESCRIPTION
Similar issue to interop-guava, hidden race condition in test that changed winner because now `as` is call by name not call by value in RC14.